### PR TITLE
Add google api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+#WWW::Shorten::Googl
+##Perl interface to goo.gl
+
+### SYNOPSIS
+
+    use WWW::Shorten::Googl;
+    use WWW::Shorten 'Googl';
+
+    $short_url = makeashorterlink($long_url);
+
+    $long_url  = makealongerlink($short_url);
+
+    # Note - this function is specific to the Googl shortener
+    $stats = getlinkstats( $short_url );
+
+### DESCRIPTION
+
+A Perl interface to the goo.gl URL shortening service. Googl simply maintains
+a database of long URLs, each of which has a unique identifier.
+
+### Functions
+
+#### makeashorterlink
+
+The function C<makeashorterlink> will call the Googl web site passing
+it your long URL and will return the shorter Googl version.
+
+If you provide your Google username and password, the link will be added
+to your list of shortened URLs at <http://goo.gl/>. See AUTHENTICATION for details.
+
+#### makealongerlink
+
+The function **makealongerlink** does the reverse.
+
+**makealongerlink**
+will accept as an argument either the full goo.gl URL or just the
+goo.gl identifier.
+
+#### getlinkstats
+
+Given a goo.gl URL, returns a hash ref with statistics about the URL.
+
+See L<http://code.google.com/apis/urlshortener/v1/reference.html#resource_url>
+for information on which data can be present in this hash ref.
+
+### Google API Key (added March 2015)
+At the time of adding this, it is necessary to provide a API Key to Google to perform the URL shortening and other services.
+Check [here](https://developers.google.com/url-shortener/v1/getting_started#APIKey) for the documentation on how to obtain a Google API key.
+The module expects to find an environment variable GOOGLE_API_KEY containing a valid key.
+If the variable is not found, the module will bail out.
+If the varibale is found but is not valid, the operation will fail and it will be reported (rather brutally) by the WWW::Shorten::generic (UserAgent).
+
+### AUTHENTICATION
+
+If you provide your Google username and password, all shortened URLs will be
+available for viewing at <http://goo.gl/>
+
+You provide these details by setting the environment variables GOOGLE_USERNAME
+and GOOGLE_PASSWORD, such as
+
+ GOOGLE_USERNAME=your.username@gmail.com
+ GOOGLE_PASSWORD=somethingVerySecret
+
+### EXPORT
+
+makeashorterlink, makealongerlink
+
+###SUPPORT, LICENCE, THANKS and SUCH
+
+See the main <WWW::Shorten> docs.
+
+###AUTHOR
+
+Magnus Erixzon <magnus@erixzon.com>
+
+###SEE ALSO
+
+<WWW::Shorten>
+<http://goo.gl/>
+<http://code.google.com/apis/urlshortener/v1/reference.html#resource_url>

--- a/lib/WWW/Shorten/Googl.pm
+++ b/lib/WWW/Shorten/Googl.pm
@@ -22,15 +22,32 @@ use Carp;
 use constant API_URL     => 'https://www.googleapis.com/urlshortener/v1/url';
 use constant HISTORY_URL => 'https://www.googleapis.com/urlshortener/v1/url/history';
 
+# 2015-03-31 adding a DEBUG variable to run in DEBUG mode
+#my $DEBUG = 1;
+my $DEBUG = 0;
+
+# 2015-03-31 - by bennythejudge (github)
+# use an environment variable - GOOGLE_API_KEY - to pass
+# the required Google API Key
 sub makeashorterlink ($) {
     my $url = shift or croak 'No URL passed to makeashorterlink';
+    
+    # check if the API key is available in the environment
+    my $google_api_key;
+    if (  ! $ENV{ GOOGLE_API_KEY } ) {
+      croak 'No GOOGLE_API_KEY environment variable set. Please check the documentation.';
+    }
+    $google_api_key = $ENV{ GOOGLE_API_KEY };
+    ($DEBUG) && print "DEBUG: google_api_key: $google_api_key \n";
 
     my $json = JSON::Any->new;
     my $content = $json->objToJson({
         longUrl => $url,
     });
 
-    my $res = _request( 'post', API_URL, Content => $content);
+    # 2015-03-31 - modifying to pass the Google API Key
+    #my $res = _request( 'post', API_URL, Content => $content);
+    my $res = _request( 'post', API_URL . '?key=' . $google_api_key , Content => $content);
     return $res->{ id } if ( $res->{ id } );
     return undef;
 }


### PR DESCRIPTION
I have made 2 changes - one is adding a README.md. The second change is to allow to pass a Google API key to the module using env vars - in line with passing a userid/password for authentication (which would not work).
